### PR TITLE
Updates past submission deadline

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,10 +6,10 @@ theme = "PaperMod2"
 # see https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-installation/#sample-configyml
 
 [menu]
-  [[menu.main]]
-    name = 'Registration'
-    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
-    weight = 2
+#  [[menu.main]]
+#    name = 'Registration'
+#    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
+#    weight = 2
 
 [params]
   [params.profileMode]

--- a/content/about.md
+++ b/content/about.md
@@ -13,10 +13,14 @@ weight: 1
 
 ---
 
+**Registration is closed. Thank you for shaping an exciting event with your contribution!**
+
+We are currently creating a schedule, and will send out acceptance emails by November 1st.
+If you’ve missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
+
 ## Call for participation
 
 The first **distribits** meeting will happen in 2024, and we are inviting all interested parties to join!
-**Registration is open now and closes October 22nd.**
 
 The aim of this meeting is to bring together enthusiasts of tools and workflows in the domain of distributed data.
 It is organized by the people behind the [git-annex](https://git-annex.branchable.com) and [DataLad](https://www.datalad.org) projects.
@@ -53,7 +57,8 @@ We plan to prioritize efforts that promote interoperability of tools and workflo
 
 ### Submit proposals and register
 
-Please submit your proposal and register via our [online submission/registration system](https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/).
+Registration and submissions are *closed*.
+If you’ve missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
 
 
 ### Contact and further information

--- a/content/news.md
+++ b/content/news.md
@@ -4,6 +4,17 @@ menu: "main"
 weight: 5
 ---
 
+## Registration is closed!
+
+Thanks for everyone's registrations and contribution submissions!
+It looks like the first distribits meeting is going to be what we hoped for:
+An inspiring event for technology enthusiasts with many backgrounds.
+We received registrations from Europe, North America, and Asia, from people working on research data curation, climate science, imaging, archeology, data portals, archiving solutions, small and scale large.
+
+We will now work on finalizing the schedule, and send out emails to everyone by November 1st.
+If you've missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
+
+
 ## Registration closes October 22nd!
 
 If you haven't yet, register for the event and hackathon via out [online submission/registration system](https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/) and tell your friends about it.

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -4,9 +4,11 @@ menu: "main"
 weight: 4
 ---
 
-**Registration opens**: September 14th
+*Registration opens: September 14th*
 
-**Registration and submission closes**: midnight October 22nd
+*Registration and submission closes: midnight October 22nd*
+
+**Registration and submission feedback**: by November 1st
 
 ### Preliminary schedule:
 


### PR DESCRIPTION
This PR
- adds a news item about the closed registration and outlining the next steps
- adds the feedback deadline to the schedule, while removing the former boldness of the submission time frame
- adjusts the index page and the submodule state accordingly.
- hides the registration link from the top page menu
- 
The necessary submodule updates are hopefully correct, and are already pushed to the upstream ``master`` branch.

Some previews: 
![image](https://github.com/distribits/distribits-2024-website/assets/29738718/e7a41795-0dde-4369-b4fd-aabdb91574f4)

![image](https://github.com/distribits/distribits-2024-website/assets/29738718/66ad2963-e100-4af8-a98e-d359a6fbc595)

![image](https://github.com/distribits/distribits-2024-website/assets/29738718/e5516b69-c351-480a-87ee-d1a883877843)
