### PR TITLE
Temporarily disable registration shortcut

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,9 +19,9 @@ theme = "PaperMod2"
     imageUrl = "pics/distribits_logo_a.svg"
     imageTitle = "distribits_logo"
     imageWidth = 800
-  [[params.profileMode.buttons]]
-    name = "🚀 Register"
-    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
+#  [[params.profileMode.buttons]]
+#    name = "🚀 Register"
+#    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
   [[params.profileMode.buttons]]
     name = "💡 About"
     url = "/about"


### PR DESCRIPTION
While the registration is closed, there is no need to have it around. It can come back once we open late registrations.