### PR TITLE
Adds details about notifications and late registration to website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,10 +6,10 @@ theme = "PaperMod2"
 # see https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-installation/#sample-configyml
 
 [menu]
-#  [[menu.main]]
-#    name = 'Registration'
-#    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
-#    weight = 2
+  [[menu.main]]
+    name = 'Registration'
+    url = 'https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/'
+    weight = 2
 
 [params]
   [params.profileMode]
@@ -19,9 +19,9 @@ theme = "PaperMod2"
     imageUrl = "pics/distribits_logo_a.svg"
     imageTitle = "distribits_logo"
     imageWidth = 800
-#  [[params.profileMode.buttons]]
-#    name = "🚀 Register"
-#    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
+  [[params.profileMode.buttons]]
+    name = "🚀 Register"
+    url = 'https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/'
   [[params.profileMode.buttons]]
     name = "💡 About"
     url = "/about"

--- a/content/about.md
+++ b/content/about.md
@@ -13,10 +13,17 @@ weight: 1
 
 ---
 
-**Registration is closed. Thank you for shaping an exciting event with your contribution!**
+**Registration Notifications and Late Submissions**
 
-We are currently creating a schedule, and will send out acceptance emails by November 1st.
-If you’ve missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
+Notifications for registration acceptance have been sent out (November 1st).
+Thank you for shaping an exciting event with your contribution!
+However, if you missed the registration deadline, don't worry! It is now possible to
+[submit a late registration](https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/)
+and add yourself to the hackathon waiting list.
+We plan to accept conference registrations until we reach the venue capacity.
+We will assess late registrations at an interval of ~ 2 weeks and will send out notification emails
+accordingly. For the hackathon, late registrations will be added to the waiting list
+and will be notified when there is a change to the application status.
 
 ## Call for participation
 

--- a/content/about.md
+++ b/content/about.md
@@ -13,7 +13,7 @@ weight: 1
 
 ---
 
-**Registration Notifications and Late Submissions**
+**Registration Notifications and Late Registrations**
 
 Notifications for registration acceptance have been sent out (November 1st).
 Thank you for shaping an exciting event with your contribution!

--- a/content/news.md
+++ b/content/news.md
@@ -4,6 +4,18 @@ menu: "main"
 weight: 5
 ---
 
+## Notifications sent and Late Registration opens!
+
+We have sent out notifications by email to all who submitted conference
+and hackathon submissions. However, if you missed the registration deadline, don't worry! It is now possible to
+[submit a late registration](https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/)
+and add yourself to the hackathon waiting list.
+We plan to accept conference registrations until we reach the venue capacity.
+We will assess late registrations at an interval of ~ 2 weeks and will send out notification emails.
+accordingly. For the hackathon, late registrations will be added to the waiting list
+and will be notified when there is a change to the application status.
+
+
 ## Registration is closed!
 
 Thanks for everyone's registrations and contribution submissions!

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -8,7 +8,9 @@ weight: 4
 
 *Registration and submission closes: midnight October 22nd*
 
-**Registration and submission feedback**: by November 1st
+*Registration and submission feedback: November 1st*
+
+**Late Registration opens, with hackathon waiting list: November 6th**
 
 ### Preliminary schedule:
 


### PR DESCRIPTION
This PR mostly has some repeated content across pages to enlighten readers about the fact that we have notified people about submissions and that we have now opened late registration. It also brings back the registration menu item and front page button and makes these point to the late registration form. Submodule master branch already has the same update pushed.