### PR TITLE
Turn news into actual news (posts with dates)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,10 +6,11 @@ theme = "PaperMod2"
 # see https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-installation/#sample-configyml
 
 [menu]
-#  [[menu.main]]
-#    name = 'Registration'
-#    url = 'https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/'
-#    weight = 2
+  [[menu.main]]
+    name = "News"
+    url = "news/"
+    weight = 5
+
 
 [params]
   [params.profileMode]

--- a/content/news/notifications-sent.md
+++ b/content/news/notifications-sent.md
@@ -1,0 +1,15 @@
+---
+title: Notifications sent and Late Registration opens
+layout: post
+date: 2023-11-06
+---
+
+We have sent out notifications by email to all who submitted conference
+and hackathon submissions. However, if you missed the registration deadline, don't worry! It is now possible to
+[submit a late registration](https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/)
+and add yourself to the hackathon waiting list.
+
+We plan to accept conference registrations until we reach the venue capacity.
+We will assess late registrations at an interval of ~ 2 weeks and will send out notification emails.
+accordingly. For the hackathon, late registrations will be added to the waiting list
+and will be notified when there is a change to the application status.

--- a/content/news/registration-closed.md
+++ b/content/news/registration-closed.md
@@ -1,10 +1,8 @@
 ---
-title: "News"
-menu: "main"
-weight: 5
+title: Registration is closed
+layout: post
+date: 2023-10-23
 ---
-
-## Registration is closed!
 
 Thanks for everyone's registrations and contribution submissions!
 It looks like the first distribits meeting is going to be what we hoped for:
@@ -13,9 +11,3 @@ We received registrations from Europe, North America, and Asia, from people work
 
 We will now work on finalizing the schedule, and send out emails to everyone by November 1st.
 If you've missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
-
-
-## Registration closes October 22nd!
-
-If you haven't yet, register for the event and hackathon via out [online submission/registration system](https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/) and tell your friends about it.
-We look forward to meeting you!

--- a/content/news/registration-closes-soon.md
+++ b/content/news/registration-closes-soon.md
@@ -1,0 +1,8 @@
+---
+title: Registration closes October 22nd!
+layout: post
+date: 2023-10-15
+---
+
+If you haven't yet, register for the event and hackathon via out [online submission/registration system](https://cryptpad.fr/form/#/2/form/view/513x1GEsXvw8rbfBzfRSPdfsu0BYZxPWH7fZIpXMBFE/) and tell your friends about it.
+We look forward to meeting you!


### PR DESCRIPTION
This change uses one of Hugo's primary features - posts:

- Use one file per news item: each markdown document with `layout: post` in header will be treated as a blog post.
- `[[menu.main]]` section in `config.toml` configures hugo to group posts placed under `news/` directory under "News" menu.
- Dates in headers define ordering.

I copied the content of current news into separate files, and used dates from `git blame` as post dates.

This is what the news page looks like. Each news item can be opened:

![Screenshot from 2023-11-06 19-05-51](https://github.com/distribits/distribits-2024-website/assets/11985212/83414fb1-8f3f-47c5-97ba-af6db11a8368)

