### PR TITLE
Make home page more minimal, tweak About page, move css overrides to this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 - The website is built with [hugo](https://gohugo.io/) and uses [a fork](https://github.com/distribits/hugo-PaperMod) of the [PaperMod](https://themes.gohugo.io/themes/hugo-papermod/) theme.
 - Theme is attached as a submodule (supports dark & light mode)
 - Content is written in Markdown and placed in `content/`
-  - By default, a file corresponds to a page, listed in the menu
-  - Blog posts can be placed in `content/posts/` folder
-- Home page (title, icons, social links) is generated from configuration values
+  - One file corresponds to one page;
+    include `menu: "main"` and `weight: N` in front matter to determine placement in the top menu.
+  - News items can be placed in `content/news/` folder, one file per news item;
+    include `layout: post` and `date: yyyy-mm-dd` in front matter to determine placement in the News page.
+- Home page (title, icons, social links) is generated based on configuration only
 - Configuration is done with toml, in `config.toml`
 - There is a github action for deploying to GitHub pages, which builds to gh-pages branch, which is deployed to the custom domain distribits.live
 - As with any static generator, the content can be built locally and deployed anywhere
@@ -18,12 +20,3 @@ git clone --recurse-submodules <repo url>
 cd distribits-2024-website
 hugo server
 ```
-
-### Note about the index page
-
-The `CALL FOR PARTICIPATION` section on the index page is a custom change
-to the `layouts/partials/index_profile.html` file in the submodule located
-at `themes/PaperMod2`. For a change to this section to reflect on the live website:
-1. update the `layouts/partials/index_profile.html` page in the submodule
-2. commit and push the changes to the fork's `master` branch at https://github.com/distribits/hugo-PaperMod
-3. commit and push the submodule update (`themes/PaperMod2`) to the repo's `main` branch at https://github.com/distribits/distribits-2024-website

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -1,0 +1,402 @@
+.page-header,
+.post-header {
+    margin: 24px auto var(--content-gap) auto;
+}
+
+.post-title {
+    margin-bottom: 2px;
+    font-size: 40px;
+}
+
+.post-description {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
+.post-meta,
+.breadcrumbs {
+    color: var(--secondary);
+    font-size: 14px;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.post-meta .i18n_list li {
+    display: inline-flex;
+    list-style: none;
+    margin: auto 3px;
+    box-shadow: 0 1px 0 var(--secondary);
+}
+
+.breadcrumbs a {
+    font-size: 16px;
+}
+
+.post-content {
+    color: var(--content);
+}
+
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+    margin: 24px 0 16px;
+}
+
+.post-content h1 {
+    margin: 40px auto 32px;
+    font-size: 40px;
+}
+
+.post-content h2 {
+    margin: 32px auto 24px;
+    font-size: 32px;
+}
+
+.post-content h3 {
+    font-size: 24px;
+}
+
+.post-content h4 {
+    font-size: 16px;
+}
+
+.post-content h5 {
+    font-size: 14px;
+}
+
+.post-content h6 {
+    font-size: 12px;
+}
+
+.post-content a,
+.toc a:hover {
+    box-shadow: 0 1px 0;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+}
+
+.post-content a code {
+    margin: auto 0;
+    border-radius: 0;
+    box-shadow: 0 -1px 0 var(--primary) inset;
+}
+
+.post-content del {
+    text-decoration: line-through;
+}
+
+.post-content dl,
+.post-content ol,
+.post-content p,
+.post-content figure,
+.post-content ul {
+    margin-bottom: var(--content-gap);
+}
+
+.post-content ol,
+.post-content ul {
+    padding-inline-start: 20px;
+}
+
+.post-content li {
+    margin-top: 5px;
+}
+
+.post-content li p {
+    margin-bottom: 0;
+}
+
+.post-content dl {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+}
+
+.post-content dt {
+    width: 25%;
+    font-weight: 700;
+}
+
+.post-content dd {
+    width: 75%;
+    margin-inline-start: 0;
+    padding-inline-start: 10px;
+}
+
+.post-content dd ~ dd,
+.post-content dt ~ dt {
+    margin-top: 10px;
+}
+
+.post-content table {
+    margin-bottom: 32px;
+}
+
+.post-content table th,
+.post-content table:not(.highlighttable, .highlight table, .gist .highlight) td {
+    min-width: 80px;
+    padding: 12px 8px;
+    line-height: 1.5;
+    border-bottom: 1px solid var(--border);
+}
+
+.post-content table th {
+    font-size: 14px;
+    text-align: start;
+}
+
+.post-content table:not(.highlighttable) td code:only-child {
+    margin: auto 0;
+}
+
+.post-content .highlight table {
+    border-radius: var(--radius);
+}
+
+.post-content .highlight:not(table) {
+    margin: 10px auto;
+    background: var(--hljs-bg) !important;
+    border-radius: var(--radius);
+    direction: ltr;
+}
+
+.post-content li > .highlight {
+    margin-inline-end: 0;
+}
+
+.post-content ul pre {
+    margin-inline-start: calc(var(--gap) * -2);
+}
+
+.post-content .highlight pre {
+    margin: 0;
+}
+
+.post-content .highlighttable {
+    table-layout: fixed;
+}
+
+.post-content .highlighttable td:first-child {
+    width: 40px;
+}
+
+.post-content .highlighttable td .linenodiv {
+    padding-inline-end: 0 !important;
+}
+
+.post-content .highlighttable td .highlight,
+.post-content .highlighttable td .linenodiv pre {
+    margin-bottom: 0;
+}
+
+.post-content code {
+    margin: auto 4px;
+    padding: 4px 6px;
+    font-size: 0.78em;
+    line-height: 1.5;
+    background: var(--code-bg);
+    border-radius: 2px;
+}
+
+.post-content pre code {
+    display: block;
+    margin: auto 0;
+    padding: 10px;
+    color: rgb(213, 213, 214);
+    background: var(--hljs-bg) !important;
+    border-radius: var(--radius);
+    overflow-x: auto;
+    word-break: break-all;
+}
+
+.post-content blockquote {
+    margin: 20px 0;
+    padding: 0 14px;
+    border-inline-start: 3px solid var(--primary);
+}
+
+.post-content hr {
+    margin: 30px 0;
+    height: 2px;
+    background: var(--tertiary);
+    border: 0;
+}
+
+.post-content iframe {
+    max-width: 100%;
+}
+
+.post-content img {
+    border-radius: 4px;
+    margin: 1rem 0;
+}
+
+.post-content img[src*="#center"] {
+    margin: 1rem auto;
+}
+
+.post-content figure.align-center {
+    text-align: center;
+}
+
+.post-content figure > figcaption {
+    color: var(--primary);
+    font-size: 16px;
+    font-weight: bold;
+    margin: 8px 0 16px;
+}
+
+.post-content figure > figcaption > p {
+    color: var(--secondary);
+    font-size: 14px;
+    font-weight: normal;
+}
+
+.toc {
+    margin: 0 2px 40px 2px;
+    border: 1px solid var(--border);
+    background: var(--code-bg);
+    border-radius: var(--radius);
+    padding: 0.4em;
+}
+
+.dark .toc {
+    background: var(--entry);
+}
+
+.toc details summary {
+    cursor: zoom-in;
+    margin-inline-start: 20px;
+}
+
+.toc details[open] summary {
+    cursor: zoom-out;
+}
+
+.toc .details {
+    display: inline;
+    font-weight: 500;
+}
+
+.toc .inner {
+    margin: 0 20px;
+    padding: 10px 20px;
+}
+
+.toc li ul {
+    margin-inline-start: var(--gap);
+}
+
+.toc summary:focus {
+    outline: 0;
+}
+
+.post-footer {
+    margin-top: 56px;
+}
+
+.post-tags li {
+    display: inline-block;
+    margin-inline-end: 3px;
+    margin-bottom: 5px;
+}
+
+.post-tags a,
+.share-buttons,
+.paginav {
+    border-radius: var(--radius);
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+}
+
+.post-tags a {
+    display: block;
+    padding-inline-start: 14px;
+    padding-inline-end: 14px;
+    color: var(--secondary);
+    font-size: 14px;
+    line-height: 34px;
+    background: var(--code-bg);
+}
+
+.post-tags a:hover,
+.paginav a:hover {
+    background: var(--border);
+}
+
+.share-buttons {
+    margin: 14px 0;
+    padding-inline-start: var(--radius);
+    display: flex;
+    justify-content: center;
+    overflow-x: auto;
+}
+
+.share-buttons a {
+    margin-top: 10px;
+}
+
+.share-buttons a:not(:last-of-type) {
+    margin-inline-end: 12px;
+}
+
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
+    display: inline-flex;
+    color: var(--secondary);
+    margin-inline-start: 8px;
+    font-weight: 500;
+    user-select: none;
+}
+
+.paginav {
+    margin: 10px 0;
+    display: flex;
+    line-height: 30px;
+    border-radius: var(--radius);
+}
+
+.paginav a {
+    padding-inline-start: 14px;
+    padding-inline-end: 14px;
+    border-radius: var(--radius);
+}
+
+.paginav .title {
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-size: small;
+    color: var(--secondary);
+}
+
+.paginav .prev,
+.paginav .next {
+    width: 50%;
+}
+
+.paginav span:hover:not(.title) {
+    box-shadow: 0 1px 0;
+}
+
+.paginav .next {
+    margin-inline-start: auto;
+    text-align: right;
+}
+
+[dir="rtl"] .paginav .next {
+    text-align: left;
+}
+
+h1>a>svg {
+    display: inline;
+}
+
+img.in-text {
+    display: inline;
+    margin: auto;
+}

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -82,6 +82,10 @@
     box-shadow: 0 -1px 0 var(--primary) inset;
 }
 
+.post-content a {
+    color: var(--distribits-pink);
+}
+
 .post-content del {
     text-decoration: line-through;
 }

--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -1,0 +1,42 @@
+.buttons,
+.main .profile {
+    display: flex;
+    justify-content: center;
+}
+
+.main .profile {
+    align-items: center;
+    min-height: calc(100vh - var(--header-height) - var(--footer-height) - (var(--gap) * 2));
+    text-align: center;
+}
+
+.profile .profile_inner h1 {
+    padding: 12px 0;
+}
+
+.profile img {
+    display: inline-table;
+    border-radius: 50%;
+}
+
+.buttons {
+    flex-wrap: wrap;
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.button {
+    background: var(--tertiary);
+    border-radius: var(--radius);
+    margin: 8px;
+    padding: 6px;
+    transition: transform 0.1s;
+}
+
+.button-inner {
+    padding: 0 8px;
+}
+
+.button:active {
+    transform: scale(0.96);
+}

--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -12,11 +12,12 @@
 
 .profile .profile_inner h1 {
     padding: 12px 0;
+    font-family: monospace;
 }
 
 .profile img {
     display: inline-table;
-    border-radius: 50%;
+    /* border-radius: 50%; */
 }
 
 .buttons {

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -1,0 +1,38 @@
+:root {
+    --gap: 24px;
+    --content-gap: 20px;
+    --nav-width: 1024px;
+    --main-width: 720px;
+    --header-height: 60px;
+    --footer-height: 60px;
+    --radius: 8px;
+    --theme: rgb(255, 255, 255);
+    --entry: rgb(255, 255, 255);
+    --primary: rgb(30, 30, 30);
+    --secondary: rgb(108, 108, 108);
+    --tertiary: rgb(214, 214, 214);
+    --content: rgb(31, 31, 31);
+    --hljs-bg: rgb(28, 29, 33);
+    --code-bg: rgb(245, 245, 245);
+    --border: rgb(238, 238, 238);
+}
+
+.dark {
+    --theme: rgb(29, 30, 32);
+    --entry: rgb(46, 46, 51);
+    --primary: rgb(218, 218, 219);
+    --secondary: rgb(155, 156, 157);
+    --tertiary: rgb(65, 66, 68);
+    --content: rgb(196, 196, 197);
+    --hljs-bg: rgb(46, 46, 51);
+    --code-bg: rgb(55, 56, 62);
+    --border: rgb(51, 51, 51);
+}
+
+.list {
+    background: var(--code-bg);
+}
+
+.dark.list {
+    background: var(--theme);
+}

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -15,6 +15,7 @@
     --hljs-bg: rgb(28, 29, 33);
     --code-bg: rgb(245, 245, 245);
     --border: rgb(238, 238, 238);
+    --distribits-pink: #ff6584;
 }
 
 .dark {

--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,6 @@ theme = "PaperMod2"
 
 [menu]
   [[menu.main]]
-    name = 'Registration'
-    url = 'https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/'
-    weight = 2
-  [[menu.main]]
     name = "News"
     url = "news/"
     weight = 5
@@ -26,12 +22,6 @@ theme = "PaperMod2"
   [[params.profileMode.buttons]]
     name = "🚀 Register"
     url = 'https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/'
-  [[params.profileMode.buttons]]
-    name = "💡 About"
-    url = "/about"
-  [[params.profileMode.buttons]]
-    name = "🔄 News"
-    url = "/news"
 
   # repeat as many times as needed
   # icon names -> grep icon_name themes/PaperMod/layouts/partials/svg.html

--- a/content/about.md
+++ b/content/about.md
@@ -4,31 +4,13 @@ menu: "main"
 weight: 1
 ---
 
----
-
+## Distribits: technologies for distributed data management
+April 18th - April 20th, 2024 at “Haus der Universität”, Düsseldorf, Germany
 ![Distribits 2024](/pics/distribits_logo_a.svg)
-## Technologies for distributed data management
-
-### April 18th - April 20th, 2024 at “Haus der Universität”, Düsseldorf, Germany
 
 ---
-
-**Registration Notifications and Late Registrations**
-
-Notifications for registration acceptance have been sent out (November 1st).
-Thank you for shaping an exciting event with your contribution!
-However, if you missed the registration deadline, don't worry! It is now possible to
-[submit a late registration](https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/)
-and add yourself to the hackathon waiting list.
-We plan to accept conference registrations until we reach the venue capacity.
-We will assess late registrations at an interval of ~ 2 weeks and will send out notification emails
-accordingly. For the hackathon, late registrations will be added to the waiting list
-and will be notified when there is a change to the application status.
-
-## Call for participation
 
 The first **distribits** meeting will happen in 2024, and we are inviting all interested parties to join!
-
 The aim of this meeting is to bring together enthusiasts of tools and workflows in the domain of distributed data.
 It is organized by the people behind the [git-annex](https://git-annex.branchable.com) and [DataLad](https://www.datalad.org) projects.
 The event will comprise a two-day conference and an additional hackathon day.
@@ -62,15 +44,23 @@ The capacity for this event is smaller. We thus ask everyone interested to indic
 We plan to prioritize efforts that promote interoperability of tools and workflows with free and open solutions.
 
 
-### Submit proposals and register
+### Registration Notifications and Late Registration
 
-Registration and submissions are *closed*.
-If you’ve missed the deadline but wanted to participate, please stay tuned - we will be able to accommodate late registrations in a short while.
+Notifications for registration acceptance have been sent out (November 1st).
+Thank you for shaping an exciting event with your contribution!
+
+However, if you missed the registration deadline, don't worry! It is now possible to
+[submit a late registration](https://cryptpad.fr/form/#/2/form/view/jnreOeG+ja0DXCESlqkgf6WRqz7vhMmxzROMyJL+q5g/)
+for the conference, and add yourself to the hackathon waiting list.
+We plan to accept conference registrations until we reach the venue capacity.
+We will assess late registrations at an interval of ~ 2 weeks and will send out notification emails
+accordingly. For the hackathon, late registrations will be added to the waiting list
+and will be notified when there is a change to the application status.
 
 
 ### Contact and further information
 
-For any further questions, please see https://distribits.live or contact distribits-org@fz-juelich.de
+For any further information or questions, please see the [News]({{<ref "/news">}}) page or contact distribits-org@fz-juelich.de.
 
 Given the free nature of the event, attendees are expected to organize and cover their own travel, accommodation, and food.
-The event takes place in downtown Düsseldorf with plenty of options available.
+The event takes place in downtown Düsseldorf with plenty of options available -- see [Location]({{<ref "/Location">}}).


### PR DESCRIPTION
This PR proposes going back to a minimalist home page, with only logo, title, social icons, buttons, and top menu (no announcement text on home page), closes #31 :

![Screenshot from 2023-11-07 14-02-22](https://github.com/distribits/distribits-2024-website/assets/11985212/d62eebd1-7697-4069-85a4-9265a36286f9)

All information which got removed from the home page was already present in About and News sections of the website.

Buttons other than registration are also removed - everything is already accessible from the top menu. Conversely, (external) registration link is removed from the menu. This keeps one link for each target, and makes the home page look leaner (this change is one commit, can be reverted if unpopular).

The About page is slightly updated; while still 90% based on the call for contributions, IMHO it should work better on its own now.

Tweaks done previously to the fork of the theme are now done in this repo, using Hugo's way to [Customize a theme](https://gohugobrasil.netlify.app/themes/customizing/) in which files placed in project's folder take precedence over contents of `themes/<theme>` (which means I copied affected css files).

Altogether, I think this should both improve the feel of the website and make adding new content easier. See individual commit messages for descriptions, and try a local build to see rendered changes.