### PR TITLE
Use hugo features to render xml schedule as part of schedule page

### DIFF
--- a/assets/xml/schedule.xml
+++ b/assets/xml/schedule.xml
@@ -1,0 +1,1 @@
+../../static/sched/distribits2024.xml

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -4,47 +4,24 @@ menu: "main"
 weight: 4
 ---
 
-*Registration opens: September 14th*
+## Important dates
 
-*Registration and submission closes: midnight October 22nd*
+- *Registration opens: September 14th*
+- *Registration and submission closes: midnight October 22nd*
+- *Registration and submission feedback: November 1st*
+- **Late Registration opens, with hackathon waiting list: November 6th**
 
-*Registration and submission feedback: November 1st*
-
-**Late Registration opens, with hackathon waiting list: November 6th**
-
-### Time and date:
-
+## At a glance
 - Conference
-  - Thursday, 4 April 2024, 9--18
-  - Friday, 5 April 2024, 9--18
+  - Thursday, 4 April 2024, 9--17
+  - Friday, 5 April 2024, 9--17
 - Hackathon
-  - Saturday, 6 April 2024, 9--18
+  - Saturday, 6 April 2024, 9--17
 
-### Raw schedule data
+## Event schedule (preliminary)
 
 You can access the (preliminary) raw schedule data as Pentabarf [XML](/sched/distribits2024.xml).
 
 For viewing the schedule on mobile, we recommend the Giggity app ([F-Droid](https://f-droid.org/packages/net.gaast.giggity/), [Google Play](https://play.google.com/store/apps/details?id=net.gaast.giggity)) -- enter the link to the schedule file inside the app.
 
-
-### Confirmed talks:
-
-In no particular order:
-
-1. My git-annex receipies for scaling (Sanders, Timothy)
-2. GIN-Tonic: (trying to) making datalad accessible to non-coders (Colomb, Julien; HU Berlin)
-3. Onedata as a Platform: Distributed Repository for Virtualizing Data and Long-term Preservation (Dutka, Lukasz; Onedata.org)
-4. Fusion of Multiple Open Source Applications for Data Management Workflows in Psychology and Neuroscience (Pfarr, Julia-Katharina; Philipps-University Marburg, CRC135 & The Adaptive Mind (TAM))
-5. Staying in Control of your Scientific Data with Git Annex (Büchau, Yann; Eberhard Karls Universität Tübingen)
-6. "git-annex is complete, right?" (Hess, Joey)
-7. Balancing Efficiency and Standardization for a Microscopic Image Repository on an HPC System (Thönnißen, Julia; Forschungszentrum Jülich, NFDI4BIOIMAGE)
-8. Optimisation in Network Engineering: Challenges and Solutions in Research Data Management (Breuer, Julius; Technische Universität Darmstadt, Chair of Fluid Systems)
-9. OpenNeuro and DataLad (Hardcastle, Nell; Stanford University)
-10. fMRI Pipelines on HPC with DataLad and ReproMan (Wexler, Joe; Stanford University)
-11. Workflow provenance-based scheduling (Martinez, Pedro; University of Calgary)
-12. Reproducible and replicable data science in the presence of patient  confidentiality concerns by utilizing git-annex and the Data Science Orchestrator (Brechtel, Markus Katharina; Research Group Cohorts in Infectious Disease and Cancer Research, University Hospitals Cologne and Frankfurt, German Centre for Infectious Diseases Research AND Kaluza, Philipp; Ghostroute Consulting)
-13. Neuroscientific data management using DataLad (Kosciessa, Julian; Donders Institute for Brain, Cognition and Behaviour, Radboud University)
-14. datalad-annex: a git-remote helper to deposit a repository in any place reachable by a git-annex special remote implementation (Hanke, Michael; Forschungszentrum Jülich)
-15. DataLad-Registry: A Registry of DataLad Datasets with Metadata (To, Isaac; Dartmouth College, Center for Open Neuroscience)
-16. "what's in the DataLad sandwich" AKA DataLad "ecosystem": overview of the core and extensions, CIs, testing, building (git-annex), logs archival (con/tinuous) (Halchenko, Yaroslav; Dartmouth College, Center for Open Neuroscience)
-17. DataLad Runner, Generator protocols. Hands-on for people interested in programming and extending (Mönch, Christian; Forschungszentrum Jülich)
+{{< schedule >}}

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -1,0 +1,41 @@
+{{/* load schedule file from global resources in assets */}}
+{{ $data := "" }}
+{{ $path := "xml/schedule.xml" }}
+{{ with resources.Get $path }}
+  {{ with unmarshal . }}
+    {{ $data = . }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get global resource %q" $path }}
+{{ end }}
+
+{{/* display each day's events */}}
+{{ range $data.day }}
+  {{/* for each day -- assumes day is a slice (array) */}}
+
+  <h2>{{ index . "-date"  }}</h2>  {{/* index to access property starting with - */}}
+
+  {{ range (compare.Conditional (reflect.IsSlice .room) .room (slice .room)) }}
+    {{/* for each room, ensuring room is a slice (array) */}}
+
+    <h3>{{ index . "-name" }}</h3>
+
+    {{ range (compare.Conditional (reflect.IsSlice .event) .event (slice .event)) }}
+      {{/* for each event, ensuring event is a slice (array) */}}
+
+      <h4>{{ .title }}</h4>
+      <p>
+        {{ .start }} ({{ .duration }})
+        {{ if reflect.IsSlice .persons.person }}
+          {{ delimit .persons.person ", " }}
+        {{ else }}
+          {{ .persons.person  }}
+        {{ end }}
+      </p>
+      {{ with .abstract }}
+        <p>{{ . }}</p>
+      {{ end }}
+
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -13,29 +13,41 @@
 {{ range $data.day }}
   {{/* for each day -- assumes day is a slice (array) */}}
 
-  <h2>{{ index . "-date"  }}</h2>  {{/* index to access property starting with - */}}
+  {{ $date := (index . "-date") }}
+  {{ $dayEvents := slice }}
+
+  <h2>{{ index . "-date"  }}</h2>
 
   {{ range (compare.Conditional (reflect.IsSlice .room) .room (slice .room)) }}
     {{/* for each room, ensuring room is a slice (array) */}}
 
-    <h3>{{ index . "-name" }}</h3>
+    {{ $roomname := (index . "-name") }}
 
-    {{ range (compare.Conditional (reflect.IsSlice .event) .event (slice .event)) }}
+    {{ range $event := (compare.Conditional (reflect.IsSlice .event) .event (slice .event)) }}
       {{/* for each event, ensuring event is a slice (array) */}}
-
-      <h4>{{ .title }}</h4>
-      <p>
-        {{ .start }} ({{ .duration }})
-        {{ if reflect.IsSlice .persons.person }}
-          {{ delimit .persons.person ", " }}
-        {{ else }}
-          {{ .persons.person  }}
-        {{ end }}
-      </p>
-      {{ with .abstract }}
-        <p>{{ . }}</p>
-      {{ end }}
-
+      {{/* add date & room to event, append to dayEvents */}}
+      {{ $event = $event | merge (dict "date" $date "room" $roomname) }}
+      {{ $dayEvents = $dayEvents | append $event }}
     {{ end }}
   {{ end }}
+
+  {{ range sort $dayEvents "start" }}
+    {{/* display all day's events ordered by start time */}}
+    <h3>{{ .title }}</h3>
+    <p>
+      {{ .start }} ({{ .duration }}) {{ .room }}
+    </p>
+    <p>
+      {{ if reflect.IsSlice .persons.person }}
+        {{ delimit .persons.person ", " }}
+      {{ else }}
+        {{ .persons.person  }}
+      {{ end }}
+    </p>
+    {{ with .abstract }}
+      <p>{{ . }}</p>
+    {{ end }}
+
+  {{ end }}
+  <hr>
 {{ end }}


### PR DESCRIPTION
This PR extends #34 (by three commits) and adds a custom [shortcode](https://gohugo.io/templates/shortcode-templates/) using hugo's ability to [parse XML files](https://gohugo.io/functions/transform/unmarshal/?search-input=time#working-with-xml), which renders contents of the schedule file as part of a page.

A shortcode `{{< schedule >}}` placed in a markdown file will be replaced with the schedule (titles, start times, speakers, abstracts). This will be generated from the xml file content on each website rebuild (which means updating the data file will update the schedule page).

The template is pretty basic - results are shown below (and, admittedly, with longer abstracts it produces a page which is quite long to scroll). In the template, I decided to merge events across rooms and display them in starting time order, which makes sense for a single-track event.

![image](https://github.com/distribits/distribits-2024-website/assets/11985212/4acdf8f1-00a5-4b88-9207-a41d26251154)