### PR TITLE
Schedule update - fill some TBAs and slight restructuring

### DIFF
--- a/static/sched/distribits2024.xml
+++ b/static/sched/distribits2024.xml
@@ -52,22 +52,8 @@
         <abstract>Welcome</abstract>
       </event>
 
-      <event guid="bdb82e56-291a-429d-af67-1c60ce41d44d">
-        <start>09:30</start>
-        <duration>00:20</duration>
-        <title>Datalad-annex</title>
-        <abstract>
-          Talk on datalad-annex, a git-remote helper to deposit a
-          repository in any place reachable by a git-annex special
-          remote implementation.
-        </abstract>
-        <persons>
-          <person>Michael Hanke</person>
-        </persons>
-      </event>
-
       <event guid="58439357-716a-443c-9659-2e941e2fa921">
-        <start>09:50</start>
+        <start>09:30</start>
         <duration>00:20</duration>
         <title>"what's in the Datalad sandwich" AKA DataLad "ecosystem"</title>
         <abstract>
@@ -76,6 +62,31 @@
         </abstract>
         <persons>
           <person>Yaroslav Halchenko</person>
+        </persons>
+      </event>
+
+      <event guid="0fdf066b-37d3-4901-b2ca-86712253b3ac">
+        <start>09:50</start>
+        <duration>00:20</duration>
+        <title>"git annex is complete, right?"</title>
+        <abstract>
+          My father has asked me this question before over the years. So
+          has an experienced developer recently. Seeing the same
+          question from two such different perspectives got me asking it
+          of myself.
+          While a new data storage system can always be added to
+          git-annex, or a new command be added to improve some use case,
+          both of those can also be accomplished without needing changes
+          to git-annex, by external remotes and more targeted frontends
+          such as Datalad.
+          So what then is the potential surface area of problem space
+          that git-annex may expand to cover? Do diminishing returns and
+          complexity make such expansions a good idea? I will explore
+          this by considering recent developments in git-annex, and the
+          impact of lesser-used features.
+        </abstract>
+        <persons>
+          <person>Joey Hess</person>
         </persons>
       </event>
 
@@ -122,28 +133,17 @@
         </persons>
       </event>
 
-      <event guid="0fdf066b-37d3-4901-b2ca-86712253b3ac">
+      <event guid="bdb82e56-291a-429d-af67-1c60ce41d44d">
         <start>10:30</start>
         <duration>00:20</duration>
-        <title>"git annex is complete, right?"</title>
+        <title>Datalad-annex</title>
         <abstract>
-          My father has asked me this question before over the years. So
-          has an experienced developer recently. Seeing the same
-          question from two such different perspectives got me asking it
-          of myself.
-          While a new data storage system can always be added to
-          git-annex, or a new command be added to improve some use case,
-          both of those can also be accomplished without needing changes
-          to git-annex, by external remotes and more targeted frontends
-          such as Datalad.
-          So what then is the potential surface area of problem space
-          that git-annex may expand to cover? Do diminishing returns and
-          complexity make such expansions a good idea? I will explore
-          this by considering recent developments in git-annex, and the
-          impact of lesser-used features.
+          Talk on datalad-annex, a git-remote helper to deposit a
+          repository in any place reachable by a git-annex special
+          remote implementation.
         </abstract>
         <persons>
-          <person>Joey Hess</person>
+          <person>Michael Hanke</person>
         </persons>
       </event>
 

--- a/static/sched/distribits2024.xml
+++ b/static/sched/distribits2024.xml
@@ -632,7 +632,7 @@
 
     <event guid="4fc2a76d-13be-41fc-bc09-cfcb170ad4ab">
       <start>13:50</start>
-      <duration>00:20</duration>
+      <duration>00:40</duration>
       <title>Reproducible and replicable data science in the presence of patient confidentiality concerns by utilizing git-annex and the Data Science Orchestrator</title>
       <abstract>
         Health-related data for patients is among the most sensitive
@@ -668,12 +668,6 @@
         <person>Markus Katharina Brechtel</person>
         <person>Philipp Kaluza</person>
       </persons>
-    </event>
-
-    <event guid="8fadd0c8-90fa-43ba-976b-3e195ac07d93">
-      <start>14:10</start>
-      <duration>00:20</duration>
-      <title>TBA</title>
     </event>
 
     <event guid="f465a39d-4ed4-4609-80e0-8373e2c28739">

--- a/static/sched/distribits2024.xml
+++ b/static/sched/distribits2024.xml
@@ -373,7 +373,7 @@
       </event>
 
       <event guid="786aa8b8-ffe9-4e00-8ec5-80ffa1a33ea3">
-        <start>14:45</start>
+        <start>15:30</start>
         <duration>00:30</duration>
         <title>Coffee</title>
         <abstract>
@@ -672,15 +672,15 @@
 
     <event guid="f465a39d-4ed4-4609-80e0-8373e2c28739">
       <start>14:30</start>
-      <duration>00:15</duration>
-      <title>Questions and panel discussion</title>
+      <duration>00:20</duration>
+      <title>TBA</title>
       <abstract>
-        Questions and panel discussion
+        TBA
       </abstract>
     </event>
 
     <event guid="44622511-c5c2-4ca8-9978-fa1a153b8f80">
-      <start>15:15</start>
+      <start>14:50</start>
       <duration>00:20</duration>
       <title>TBA</title>
       <abstract>
@@ -692,11 +692,11 @@
     </event>
 
     <event guid="a81918df-a057-48b1-b016-ce31f59b02a3">
-      <start>15:35</start>
+      <start>15:10</start>
       <duration>00:20</duration>
-      <title>TBA</title>
+      <title>Questions and panel discussion</title>
       <abstract>
-        TBA
+        Questions and panel discussion
       </abstract>
     </event>
 


### PR DESCRIPTION
- [x] Data science orchestrator talk is longer (equivalent of two time slots)
- [x] Friday afternoon talks are blocked into one session, coffee slightly later
- [x] Monday morning speakers change order
- [ ] Two remaining slots are To Be Announced -> separate PR

See commit messages for description