### PR TITLE
Adds navigation links to "at a glance" sections

### DIFF
--- a/content/schedule.md
+++ b/content/schedule.md
@@ -13,10 +13,10 @@ weight: 4
 
 ## At a glance
 - Conference
-  - Thursday, 4 April 2024, 9--17
-  - Friday, 5 April 2024, 9--17
+  - [Thursday, 4 April 2024, 9--17](#2024-04-04)
+  - [Friday, 5 April 2024, 9--17](#2024-04-05)
 - Hackathon
-  - Saturday, 6 April 2024, 9--17
+  - [Saturday, 6 April 2024, 9--17](#2024-04-06)
 
 ## Event schedule (preliminary)
 

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -16,7 +16,7 @@
   {{ $date := (index . "-date") }}
   {{ $dayEvents := slice }}
 
-  <h2>{{ index . "-date"  }}</h2>
+  <h2 id='{{ index . "-date"  }}' >{{ index . "-date"  }}</h2>
 
   {{ range (compare.Conditional (reflect.IsSlice .room) .room (slice .room)) }}
     {{/* for each room, ensuring room is a slice (array) */}}


### PR DESCRIPTION
This PR: 
- adds `id` fields to the day-headings in the schedule layout
- add links to these headings via the 'at a glance' bullet points
- closes https://github.com/distribits/distribits-2024-website/issues/38

It's a quick solution, and I didn't look into an option to split it into morning/afternoon slots with links.