### PR TITLE
add site with info about live stream

### DIFF
--- a/content/livestream.md
+++ b/content/livestream.md
@@ -11,5 +11,5 @@ Join us virtually in two live streams on April 4th and April 5th via the [DataLa
 * Live stream of conference day 1: [Take me there](https://youtube.com/live/BwRy3z_hQ70?feature=share)
 * Live stream of conference day 2: [Take me there](https://youtube.com/live/L1MKaUgg1xs?feature=share)
 
-During and after a talk, you can ask questions via the [Distribits meeting Q&A](https://matrix.to/#/!zgDTuNhNsLsAWNOtcs:matrix.org?via=matrix.org&via=matrix.uni-marburg.de&via=inm7.de) Matrix Room.
+During and after a talk, you can ask questions via the **Distribits meeting Q&A** Matrix Room. The link to this room has been sent to all attendees via email.
 Keep in mind that the live stream is part of the conference, and thus covered by the [Code of Conduct]( {{< ref "/code-of-conduct" >}} ).

--- a/content/livestream.md
+++ b/content/livestream.md
@@ -1,0 +1,15 @@
+---
+title: "Live Stream"
+menu: "main"
+weight: 2
+---
+
+## Watch the conference online
+
+Join us virtually in two live streams on April 4th and April 5th via the [DataLad YouTube Channel](https://www.youtube.com/@DataLad/streams)!
+
+* Live stream of conference day 1: [Take me there](https://youtube.com/live/BwRy3z_hQ70?feature=share)
+* Live stream of conference day 2: [Take me there](https://youtube.com/live/L1MKaUgg1xs?feature=share)
+
+During and after a talk, you can ask questions via the [Distribits meeting Q&A](https://matrix.to/#/!zgDTuNhNsLsAWNOtcs:matrix.org?via=matrix.org&via=matrix.uni-marburg.de&via=inm7.de) Matrix Room.
+Keep in mind that the live stream is part of the conference, and thus covered by the [Code of Conduct]( {{< ref "/code-of-conduct" >}} ).


### PR DESCRIPTION
To have info for virtual attendees searching for the live stream on the website.

To keep a record about the YouTube streams (see also https://github.com/distribits/distribits-2024/issues/29): The streams are configured to be public, comments are turned off. 