### PR TITLE
List two speakers as separate persons in schedule xml

### DIFF
--- a/static/sched/distribits2024.xml
+++ b/static/sched/distribits2024.xml
@@ -285,7 +285,8 @@
           complex landscape of digital data preservation.
         </abstract>
         <persons>
-          <person>Łukasz Dutka and Łukasz Opioła</person>
+          <person>Łukasz Dutka</person>
+          <person>Łukasz Opioła</person>
         </persons>
       </event>
 


### PR DESCRIPTION
This is mostly for syntactic purity, but there is a small practical component: giggity will pick up many persons and show them as speakers (plural) in the event card (as opposed to speaker, when there is only one).